### PR TITLE
Avoid: Error running make docs in peg-markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ docs: $(PROGRAM)
 	mkdir -p ../manual; \
 	../multimarkdown manual.txt > ../manual/index.html; \
 	../multimarkdown -b -t latex manual.txt; \
-	latexmk manual.tex; \
+	latexmk -pdf manual.tex; \
 	latexmk -c manual.tex; \
 	mv manual.pdf ../manual/mmd-manual.pdf; \
 	rm ../documentation/manual.t*;


### PR DESCRIPTION
This is to avoid requiring all users to have a ~/.latexmkrc containing

```
$pdf_mode = 1;
```

See the thread: "Error running make docs in peg-markdown"
http://groups.google.com/group/multimarkdown/browse_thread/thread/765c1c1e681ea069?hl=en
