### PR TITLE
Added markdown_with_visitor and markdown_visit_element_list.

### DIFF
--- a/MultiMarkdown.xcodeproj/project.pbxproj
+++ b/MultiMarkdown.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -318,10 +318,10 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0410;
+				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = 1DEB928908733DD80010E9CD /* Build configuration list for PBXProject "MultiMarkdown" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (

--- a/markdown_lib.c
+++ b/markdown_lib.c
@@ -27,7 +27,7 @@
 
 /* preformat_text - allocate and copy text buffer while
  * performing tab expansion. */
-static GString *preformat_text(char *text) {
+GString *preformat_text(char *text) {
     GString *buf;
     char next_char;
     int charstotab;
@@ -115,7 +115,7 @@ static void print_tree(element * elt, int indent) {
 /* process_raw_blocks - traverses an element list, replacing any RAW elements with
  * the result of parsing them as markdown text, and recursing into the children
  * of parent elements.  The result should be a tree of elements without any RAWs. */
-static element * process_raw_blocks(element *input, int extensions, element *references, element *notes, element *labels) {
+element * process_raw_blocks(element *input, int extensions, element *references, element *notes, element *labels) {
     element *current = NULL;
     element *last_child = NULL;
     char *contents;

--- a/markdown_peg.h
+++ b/markdown_peg.h
@@ -140,4 +140,6 @@ char * extract_metadata_value(char *text, int extensions, char *key);
 char * metavalue_for_key(char *key, element *list);
 
 element * parse_markdown_for_opml(char *string, int extensions);
+
+element * element_for_attribute(char *querystring, element *list);
 #endif

--- a/markdown_visitor.c
+++ b/markdown_visitor.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "markdown_lib.h"
+#include "markdown_visitor.h"
+
+GString *preformat_text(char *text);
+element *process_raw_blocks(element *input, int extensions, element *references, element *notes, element *labels);
+
+static element *visit_headingsection(element *list, markdown_visitor visitor, void *user_data);
+static void visit_element(element *elt, markdown_visitor visitor, void *user_data);
+
+
+void markdown_visit_element_list(element *list, markdown_visitor visitor, void *user_data) {
+    while (list != NULL) {
+        if (list->key == HEADINGSECTION) {
+            list = visit_headingsection(list, visitor, user_data);
+        } else {
+            visit_element(list, visitor, user_data);
+            list = list->next;
+        }
+    }
+}
+
+static element *visit_headingsection(element *list, markdown_visitor visitor, void *user_data) {
+    element *base = list;
+    markdown_visit_element_list(list->children, visitor, user_data);
+    
+    list = list->next;
+    while ( (list != NULL) && (list->key == HEADINGSECTION) && (list->children->key > base->children->key) && (list->children->key <= H6)) {
+        list = visit_headingsection(list, visitor, user_data);
+    }
+    
+    return list;
+}
+
+static void visit_element(element *elt, markdown_visitor visitor, void *user_data) {
+    visitor(elt, user_data);
+}
+
+void markdown_with_visitor(char *text, int extensions, markdown_visitor visitor, void *user_data) {
+    element *result;
+    element *references;
+    element *notes;
+    element *labels;
+    GString *formatted_text;
+    
+    formatted_text = preformat_text(text);
+    
+    references = parse_references(formatted_text->str, extensions);
+    notes = parse_notes(formatted_text->str, extensions, references);
+    labels = parse_labels(formatted_text->str, extensions, references, notes);
+    result = parse_markdown_with_metadata(formatted_text->str, extensions, references, notes, labels);
+    
+    result = process_raw_blocks(result, extensions, references, notes, labels);
+
+    g_string_free(formatted_text, TRUE);
+
+    markdown_visit_element_list(result, visitor, user_data);
+
+    free_element_list(result);
+    
+    free_element_list(references);
+    free_element_list(labels);
+}

--- a/markdown_visitor.h
+++ b/markdown_visitor.h
@@ -1,0 +1,13 @@
+#ifndef MultiMarkdown_Visitor_h
+#define MultiMarkdown_Visitor_h
+
+#include "markdown_peg.h"
+
+typedef void (*markdown_visitor)(element *elt, void *user_data);
+
+void markdown_visit_element_list(element *list, markdown_visitor visitor, void *user_data);
+
+void markdown_with_visitor(char *text, int extensions, markdown_visitor visitor, void *user_data);
+
+
+#endif


### PR DESCRIPTION
This makes it easier to add custom output formats by visiting each markdown element. This does require exposing `element_for_attribute` and making `preformat_text` and `process_raw_blocks` non-static. No exiting code was changed. The visitor pattern was layered on top of existing logic.
